### PR TITLE
Fix quartz sync workflow path issue

### DIFF
--- a/.github/workflows/gt7-telemetry-server.yaml
+++ b/.github/workflows/gt7-telemetry-server.yaml
@@ -129,7 +129,7 @@ jobs:
           tags: |
             type=raw,value=${{ steps.version.outputs.version }}
             type=ref,event=branch
-            type=ref,event=pr
+            type=ref,event=pr,prefix=pr,suffix=,pattern={{.number}}
             type=sha
 
       - name: Build and push image

--- a/.github/workflows/sync-quartz.yaml
+++ b/.github/workflows/sync-quartz.yaml
@@ -102,15 +102,15 @@ jobs:
         with:
           repository: jackyzha0/quartz
           ref: ${{ steps.find_latest_tag.outputs.new_tag }}
-          path: /tmp/quartz_upstream
+          path: quartz_upstream
           fetch-depth: 1 # Only need the content of this specific tag
 
       - name: Sync upstream content into your 'website' directory
         if: steps.find_latest_tag.outputs.new_tag_found == 'true'
         run: |
           mkdir -p website
-          echo "Syncing files from /tmp/quartz_upstream/ (tag: ${{ steps.find_latest_tag.outputs.new_tag }}) to website/"
-          rsync -av --delete --exclude='.git/' /tmp/quartz_upstream/ website/
+          echo "Syncing files from quartz_upstream/ (tag: ${{ steps.find_latest_tag.outputs.new_tag }}) to website/"
+          rsync -av --delete --exclude='.git/' quartz_upstream/ website/
           echo "Sync complete. website/package.json should now reflect version ${{ steps.find_latest_tag.outputs.new_tag }}."
 
       - name: Create Pull Request with synced changes

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -29,6 +29,10 @@
   "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
   "packageRules": [
     {
+      "matchManagers": ["cargo"],
+      "postUpdateOptions": ["cargoUpdateLockfile"]
+    },
+    {
       "addLabels": ["renovate/container", "type/major"],
       "additionalBranchPrefix": "{{parentDir}}-",
       "commitMessageExtra": " ( {{currentVersion}} → {{newVersion}} )",

--- a/gt7/telemetry-server/Cargo.lock
+++ b/gt7/telemetry-server/Cargo.lock
@@ -2372,6 +2372,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2595,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,15 +2740,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2726,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2785,12 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"

--- a/gt7/telemetry-server/Cargo.lock
+++ b/gt7/telemetry-server/Cargo.lock
@@ -310,39 +310,11 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.2",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -353,7 +325,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -368,27 +340,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -416,22 +367,21 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
- "axum 0.7.9",
- "axum-core 0.4.5",
+ "axum",
+ "axum-core",
  "bytes",
- "fastrand",
  "futures-util",
  "headers",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "tower",
  "tower-layer",
@@ -1181,7 +1131,7 @@ dependencies = [
 name = "gt7-telemetry-server"
 version = "0.1.0"
 dependencies = [
- "axum 0.8.4",
+ "axum",
  "axum-extra",
  "bitflags 2.9.1",
  "byteorder",
@@ -1762,12 +1712,6 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1808,23 +1752,6 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.3.1",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]

--- a/gt7/telemetry-server/Cargo.toml
+++ b/gt7/telemetry-server/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 env_logger = "0.11"
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8.4", features = ["ws"] }
-axum-extra = { version = "0.9.6", features = ["typed-header"] }
+axum-extra = { version = "0.10.0", features = ["typed-header"] }
 futures-util = "0.3"
 openssl = { version = "0.10.59", features = ["vendored"] }
 


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workspace path restriction error in quartz sync workflow
- Change checkout path from `/tmp/quartz_upstream` to `quartz_upstream`
- Update rsync command to use the corrected relative path

## Problem
The workflow was failing with: `Repository path '/tmp/quartz_upstream' is not under '/home/runner/work/goyangi/goyangi'`

GitHub Actions restricts repository checkouts to within the runner's workspace directory for security reasons.

## Solution
- Changed checkout path to a relative path within the workspace
- Updated all references in the sync step to use the new path

Fixes issue in workflow run: https://github.com/solanyn/goyangi/actions/runs/15652814919/job/44099845056